### PR TITLE
change gulp styles config paths in order to exclude the '_tmp' files …

### DIFF
--- a/gulp/config/styles.js
+++ b/gulp/config/styles.js
@@ -9,7 +9,7 @@ var assets = require('./common').paths.assets;
  */
 module.exports = {
 	paths: {
-		watch: assets.src  + '/scss/**/*.scss',
+		watch: [assets.src + '/scss/**/*.scss', '!' + assets.src + '/scss/**/*_tmp\\d+.scss'],
 		src:   [assets.src + '/scss/*.scss', '!' + assets.src + '/scss/**/_*'],
 		dest:  assets.dest + '/css',
 		clean: assets.dest + '/css/**/*.{css,map}'


### PR DESCRIPTION
…that the scss-linter creates
