### PR TITLE
Updated lazysizes to version 1.2.3-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webpack-stream": "2.1.1"
   },
   "dependencies": {
-    "lazysizes": "1.2.2",
+    "lazysizes": "1.2.3-rc2",
     "object-fit": "0.4.3",
     "picturefill": "3.0.1"
   }


### PR DESCRIPTION
:rocket:

lazysizes just published version 1.2.3-rc2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 9 commits (ahead by 9, behind by 0).
- [dbe699d](https://github.com/aFarkas/lazysizes/commit/dbe699d4dcaf3a3bd89dcee27bb0ce4e96ddd560): 1.2.3-rc2
- [b24400c](https://github.com/aFarkas/lazysizes/commit/b24400c4a0e0edf9b77483ea0a9c8fb75ce30afb): improve whitespace/multiline handling (fixes #170)
- [c63415f](https://github.com/aFarkas/lazysizes/commit/c63415f85394fdf7c68fcb64a6ae28f4e1b3c390): cleanup vars
- [a8d7788](https://github.com/aFarkas/lazysizes/commit/a8d7788292cdf91d7a077c6768c1cecaff5d9a9b): change expand value
- [7eba3c4](https://github.com/aFarkas/lazysizes/commit/7eba3c472a8e71190ce181be3e19048e0eea59bf): test for className + className.indexOf (fixes #161)
- [ed8390d](https://github.com/aFarkas/lazysizes/commit/ed8390df7f2ff84ef6ac6326bf498d607640b914): partial revert
- [5ce06c0](https://github.com/aFarkas/lazysizes/commit/5ce06c0313054260bb7099e388554e58b61d58be): 1.2.3-rc1
- [e73394b](https://github.com/aFarkas/lazysizes/commit/e73394bbe25f6a3e457b6e6729cf45d6d38d80b5): fix amd support (see #159)
- [6928918](https://github.com/aFarkas/lazysizes/commit/69289181a1226674b12c8a55893fa15b8762f85c): docs

See the [full diff](https://github.com/aFarkas/lazysizes/compare/5b99903710703f07ade50689f0a78c50c2954619...dbe699d4dcaf3a3bd89dcee27bb0ce4e96ddd560).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
