### PR TITLE
Updated browser-sync to version 2.9.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-core": "5.8.25",
     "babel-loader": "5.3.2",
     "bower-webpack-plugin": "0.1.9",
-    "browser-sync": "2.9.8",
+    "browser-sync": "2.9.10",
     "del": "2.0.2",
     "eslint": "1.6.0",
     "eslint-loader": "1.0.0",


### PR DESCRIPTION
:rocket:

browser-sync just published version 2.9.10, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [fece1f7](https://github.com/BrowserSync/browser-sync/commit/fece1f754c981140a35f75e4557a5fe215362b62): 2.9.10
- [a18cdc3](https://github.com/BrowserSync/browser-sync/commit/a18cdc3cd6d7f21f45f38e857e15a73d282c9e21): tests: cleanup some lingering state in legacy tests
- [ddd4213](https://github.com/BrowserSync/browser-sync/commit/ddd4213fcfaba25a35a5cca6dc63d23243546be8): fix(cleanup): close any watchers registered in options - fixes #855
- [fe716bb](https://github.com/BrowserSync/browser-sync/commit/fe716bb382172df638bbea74aea6e6f988e80515): 2.9.9
- [01056c5](https://github.com/BrowserSync/browser-sync/commit/01056c5b8f9a4f9aaa644b1c9960094e98d2d443): deps: bump browser-sync-client@2.3.2 for fixes relating to #449
- [12095f3](https://github.com/BrowserSync/browser-sync/commit/12095f376279b82214da87231efc9d7943f1719b): deps: pin meow@3.3 until https://github.com/sindresorhus/meow/issues/11 is resolved

See the [full diff](https://github.com/BrowserSync/browser-sync/compare/1d86f1a8bae3d9228f732d3022644c2ebe521186...fece1f754c981140a35f75e4557a5fe215362b62).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
