### PR TITLE
[feature] Override the include path option. Useful for Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Thanks to [Ryanlanciaux](http://ryanlanciaux.github.io/blog/2014/08/02/using-jes
 	- use `npm install --save <module(s)>` or `bower install --save <module(s)>` to easily manage js dependencies, then use `var <module> = require('<module>');`
 	  or `import <module> from '<module>';` anywhere in your js files you want to use them
 	- explore the [`/library` directory](https://github.com/MozaikAgency/wp-theme-starter/tree/master/theme/library) in the dev theme for anything useful to your project.
+	- Set `override_file_path` in `gulp/config/common.js` to change the include path.
 
 ### Production
 

--- a/gulp/core/config/common.js
+++ b/gulp/core/config/common.js
@@ -12,6 +12,17 @@ var overrides = require('../../config/common');
  *
  */
 module.exports = deepMerge({
+	/**
+	 * Configure the following setting to replace the filepath which is
+	 * used in dev mode. The override_file_path.src is replaced with
+	 * override_file_path.dest. Useful when you run gulp on the local
+	 * machine and use vagrant for your dev machine.
+	 * 
+	 */
+	// 'override_file_path': {
+	// 	'src': '/the/build/path',
+	// 	'dest': '/the/include/path'
+	// },
 	paths: {
 		theme: {
 			src: 'theme',

--- a/gulp/core/templates/devmode-php-include.js
+++ b/gulp/core/templates/devmode-php-include.js
@@ -1,9 +1,20 @@
+var config       = require('../config/common');
+
 module.exports = function (filename, definitions) {
 
 	var preservedDefs = (definitions && definitions.length)
 		? ' * ' + definitions.join('\n * ') + '\n *'
 		: ' *';
 	
+	/**
+	 * Replace the file path in case config.override_file_path is set.
+	 */
+	if(typeof config.override_file_path != "undefined")
+	{
+		var filename = filename.replace( config.override_file_path.src, config.override_file_path.dest);
+
+	}
+
 	return [
 		'<?php',
 		'/**',


### PR DESCRIPTION
I use Homestead to develop PHP applications, including WordPress. Unfortunately there is a performance difference when you run gulp on homestead and on your local machine. I prefer to run gulp on the local machine in watch mode (as this feature also does not work inside Homestead) and set the include path to the path inside the vm.

This feature is by default turned off.
