### PR TITLE
remove pure_getters: true UglifyJS option

### DIFF
--- a/gulp/core/config/scripts.js
+++ b/gulp/core/config/scripts.js
@@ -59,7 +59,6 @@ module.exports = deepMerge({
 						screw_ie8: true,
 						compress: {
 							drop_console: true,
-							pure_getters: true,
 							unsafe: true,
 							unsafe_comps: true,
 							screw_ie8: true,


### PR DESCRIPTION
This fixes the issue that @joseelsantos had with Greensock (https://github.com/MozaikAgency/wp-theme-starter/issues/251)
