### PR TITLE
Add support for saving JSON files of Advanced Custom Fields Pro

### DIFF
--- a/gulp/core/recipes/theme/dev.js
+++ b/gulp/core/recipes/theme/dev.js
@@ -21,6 +21,7 @@ var config       = require('../../config/theme');
 var includeDev   = require('../../templates/devmode-php-include');
 var style        = require('../../templates/wordpress-style-css');
 var bSSnippet    = require('../../templates/browser-sync-snippet');
+var ACFSnippet   = require('../../templates/advanced-custom-fields-snippet');
 
 /**
  * Move the Theme to
@@ -67,6 +68,7 @@ module.exports = function () {
 		                  // functions.php so we need to
 		                  // filter the gulp stream
 		.pipe(insert.append(bSSnippet))
+		.pipe(insert.append(ACFSnippet))
 		.pipe(filterFunc.restore)
 
 		.pipe(gulp.dest(config.paths.dest))

--- a/gulp/core/templates/advanced-custom-fields-snippet.js
+++ b/gulp/core/templates/advanced-custom-fields-snippet.js
@@ -1,0 +1,24 @@
+var project = require('../../../project.config');
+
+const dir = __dirname.replace('/gulp/core/templates', '');
+const theme_name = (dir.substr(dir.lastIndexOf('/') + 1));
+
+module.exports = [
+    '\n\n\n',
+    '/**',
+    ' * DEVELOPMENT MODE ONLY',
+    ' *',
+    ' * Change the ACF location for saving config files',
+    ' * (https://www.advancedcustomfields.com/resources/local-json)',
+    ' *',
+    ' * Run "gulp build" to generate the theme',
+    ' * for production before deploying!',
+    ' *',
+    ' */',
+    'if(class_exists(\'acf\')) {',
+    '\tadd_filter(\'acf/settings/save_json\', function ($path) {',
+    '\t\treturn get_theme_root() . \'/' + theme_name + '/theme/acf-json\';',
+    '\t});',
+    '}',
+    ''
+].join('\n');


### PR DESCRIPTION
When running the theme in development mode (through gulp) a snippet will be injected into functions.php that makes sure that the field data is saved into the acf-json folder of the development theme. 
